### PR TITLE
由Qyh发起的提交

### DIFF
--- a/auto_questions_v1_2/proposition/prop.py
+++ b/auto_questions_v1_2/proposition/prop.py
@@ -100,7 +100,7 @@ class Proposition(element.Element):
         Returns:
             bool: 两个命题是否相等
         """
-        return super().__eq__(other) and self.askable == other.askable
+        return super().__eq__(other) and self.askable == other.askable and self.precise == other.precise
     
     def __ne__(self, value: object) -> bool:
         """判断两个命题是否不相等，本质上是判断两个命题的类型和属性是否不相等

--- a/auto_questions_v1_2/proposition/scene.py
+++ b/auto_questions_v1_2/proposition/scene.py
@@ -51,6 +51,7 @@ class Scene(metaclass = abc.ABCMeta):
         self._knowledges: list[prop.Proposition] = []
         self.graph: Graph = None
         self.chain: str = ""
+        self._reachables: list[prop.Proposition] = [] # 可达命题列表
 
     def add_knowledge(self, number: int = 5, seed: Union[int, float, None] = None, file_path: Union[str, Path, None] = None) -> None:
         """添加知识命题
@@ -85,7 +86,7 @@ class Scene(metaclass = abc.ABCMeta):
         print(f"命题组合搜索结束.")
         print(f"获取推理图.")
         rm = RM(deepcopy(self._chosen_group), self.relations, self.rules, deepcopy(self._knowledges), graph_construct=True)
-        rm.run()
+        self._reachables = rm.run() # 11-12修改: 将建立推理图得到的命题加入可达命题列表
         self.graph = rm.graph
         print(f"推理图获取完毕.")
 
@@ -119,7 +120,8 @@ class Scene(metaclass = abc.ABCMeta):
         # 修改：选择的命题需要是未进入描述的命题
         # 修改：提问的命题需要是可提问的命题
         print("随机选择一个未进入描述的命题，提问.")
-        self._asked_prop = random.choice([i for i in self._all_props if not i.got(self._chosen_group) and i.askable])
+        self._asked_prop = random.choice([i for i in self._reachables if not i.got(self._chosen_group) and i.askable])
+        # self._asked_prop = random.choice([i for i in self._all_props if not i.got(self._chosen_group) and i.askable])
         self._ask_info = self._asked_prop.ask(self.temps)
         print("提问完毕.")
         return self._ask_info
@@ -136,7 +138,8 @@ class Scene(metaclass = abc.ABCMeta):
             Dict[str, Any]: 答案信息
         """
         assert self._asked_prop is not None, "必须先执行ask()方法进行提问"
-        am = AM(self._all_props, self._asked_prop, self._ask_info, seed, options, all_wrong_prob)
+        # am = AM(self._all_props, self._asked_prop, self._ask_info, seed, options, all_wrong_prob)
+        am = AM(self._reachables, self._asked_prop, self._ask_info, seed, options, all_wrong_prob)
         for k, v in self._value_range.items():
             am.set_value_range(k, v)
         return am.run()

--- a/auto_questions_v1_2/timereasoning/machines.py
+++ b/auto_questions_v1_2/timereasoning/machines.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tqdm import tqdm
 import random
 from typing import Any
+from itertools import product
 
 sys.path.append(Path(__file__).resolve().parents[1].as_posix())
 
@@ -113,9 +114,21 @@ class SearchMachine:
         elif type(e) == event.DurativeEvent:
             second = random.choice(("end", "duration"))
             if second == "end":
-                double = self._find_all_props(e.start_event) + self._find_all_props(e.end_event)
+                # double = self._find_all_props(e.start_event) + self._find_all_props(e.end_event)
+                # 11-12修改：将持续时间事件的结束事件与开始事件的命题组合
+                double: list[list[timeprop.TimeP]] = []
+                start_props = self._find_all_props(e.start_event) # 开始事件的命题
+                end_props = self._find_all_props(e.end_event) # 结束事件的命题
+                for startp, endp in product(start_props, end_props):
+                    double.append(startp + endp)
             else:
-                double = self._find_all_props(e.start_event) + self._find_all_props(e.duration_event)
+                # double = self._find_all_props(e.start_event) + self._find_all_props(e.duration_event)
+                # 11-12修改：将持续时间事件的开始事件与持续时间事件的命题组合
+                double: list[list[timeprop.TimeP]] = []
+                start_props = self._find_all_props(e.start_event)
+                duration_props = self._find_all_props(e.duration_event)
+                for startp, durationp in product(start_props, duration_props):
+                    double.append(startp + durationp)
             candidates.extend(double)
         elif type(e) == event.FreqEvent:
             pass

--- a/auto_questions_v1_2/timereasoning/scene.py
+++ b/auto_questions_v1_2/timereasoning/scene.py
@@ -113,7 +113,7 @@ class TimeScene(Scene):
         print(f"命题组合搜索结束.")
         print(f"获取推理图.")
         rm = RM(deepcopy(self._chosen_group), self.relations, self.rules, deepcopy(self._knowledges), graph_construct=True)
-        rm.run()
+        self._reachables = rm.run() # 11-12修改: 将建立推理图得到的命题加入可达命题列表
         self.graph = rm.graph
         print(f"推理图获取完毕.")
 
@@ -124,7 +124,8 @@ class TimeScene(Scene):
     
     def ask(self, seed: int | float | None = None) -> Dict[str, Any]:
         info = super().ask(seed)
-        all_elements = [i.element for i in self._all_props if isinstance(i, timeprop.SingleTimeP)]
+        # all_elements = [i.element for i in self._all_props if isinstance(i, timeprop.SingleTimeP)]
+        all_elements = [i.element for i in self._reachables if isinstance(i, timeprop.SingleTimeP)]
         if "element" in (typ := info.get(prop.TYPE)):
             ans = info.get(prop.ANSWER)
             if isinstance(ans, (event.TemporalEvent, event.DurativeEvent, event.FreqEvent)):

--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,5 @@
 - [auto_questions_v1_0](auto_questions_v1_0): 时间推理器程序文件（于2024-08-16弃用）
 - [auto_questions_v1_1](auto_questions_v1_1): 时间推理器程序文件（已经弃用）
 - [auto_questions_v1_2](auto_questions_v1_2): 时间推理器程序文件(当前正在使用)
+
+目前使用的Python版本是[3.12.1](https://www.python.org/downloads/release/python-3121/)


### PR DESCRIPTION
本提交主要修改时间领域专用搜索机的实现方式。主要修改有：

1. [修改时间领域专用搜索机，修复抽取的命题无法推出结果的错误](https://github.com/hezonglianheng/TimeReasoning/commit/49493e6c2b0f12aa3e215b6a0a7d26cc3755b3df)
2. 增加“可及命题”概念，被询问的命题改为从可及命题中获得。
3. 其他修订和说明信息更新。

目前测试中，对于所有的试题，均可以从条件推出结果（这可以从试题都可以获得推理链推知）。