### PR TITLE
从Reconstruct分支发起提交

### DIFF
--- a/auto_questions_v1_3/knowledge_base/scenario/cyclic.json5
+++ b/auto_questions_v1_3/knowledge_base/scenario/cyclic.json5
@@ -194,8 +194,8 @@
             "judge": [
                 "after1['event2'] == after2['event1']", 
                 "after1['diff'] + after2['diff'] == period['duration']",
-                // 08-30规则修订：before1的event1不等于before2的事件2
-                "before1['event1'] != before2['event2']",
+                // 08-30规则修订：after1的event1不等于after2的事件2
+                "after1['event1'] != after2['event2']",
             ],
             "conclusion": [
                 {


### PR DESCRIPTION
主要修改：
完善cyclic情景的规则，目前simultaneous类命题不能出现前后项事件一样的情况